### PR TITLE
ISO1: make setup.sh accept params for assisted service and agent images

### DIFF
--- a/iso1_agent_config.sh
+++ b/iso1_agent_config.sh
@@ -154,8 +154,8 @@ podman run --privileged -d --name registry -p 5000:5000 -v /mnt/agentdata/regist
 cp -r /mnt/sr1/images /mnt/agentdata/
 
 # Push AI images to registry (just for testing, latest images should be in the release payload)
-skopeo copy dir:/mnt/sr1/images/ose-agent-installer-node-agent docker://0.0.0.0:5000/masayag/assisted-installer-agent:billi --dest-tls-verify=false
-skopeo copy dir:/mnt/sr1/images/ose-agent-installer-api-server docker://0.0.0.0:5000/nmagnezi/assisted-service:appliance2 --dest-tls-verify=false
+skopeo copy dir:/mnt/sr1/images/ose-agent-installer-node-agent docker://0.0.0.0:5000/$ASSISTED_INSTALLER_AGENT_IMAGE --dest-tls-verify=false
+skopeo copy dir:/mnt/sr1/images/ose-agent-installer-api-server docker://0.0.0.0:5000/$ASSISTED_SERVICE_IMAGE --dest-tls-verify=false
 
 printf '\\\\\\\e{yellow}Pushing OC mirror to a local registry...\\\n\\\\\\\e{reset}' | set_issue "\${status_issue}"
 cp /mnt/sr1/bin/oc-mirror /usr/local/bin/


### PR DESCRIPTION
@danielerez 

generated setup.sh looks good:

bash
```
#!/bin/bash

source issue_status.sh

status_issue="00_setup"

# Mount assets ISO
mkdir /mnt/sr1
mount -t auto /dev/sr1 /mnt/sr1

# Mount agent ISO
mkdir /mnt/sr2
mount -t auto /dev/sr2 /mnt/sr2

# Load registry image
podman load -q -i /mnt/sr1/images/registry.tar

# Run local registry image
mkdir -p /mnt/agentdata
mount -t auto /dev/disk/by-partlabel/agentdata /mnt/agentdata
mkdir -p /mnt/agentdata/registry
podman run --privileged -d --name registry -p 5000:5000 -v /mnt/agentdata/registry:/var/lib/registry --restart=always docker.io/library/registry:2

# Copy images to sda (so the Agent ISO could load registry.tar)
cp -r /mnt/sr1/images /mnt/agentdata/

# Push AI images to registry (just for testing, latest images should be in the release payload)
skopeo copy dir:/mnt/sr1/images/ose-agent-installer-node-agent docker://0.0.0.0:5000/quay.io/masayag/assisted-installer-agent:billi --dest-tls-verify=false
skopeo copy dir:/mnt/sr1/images/ose-agent-installer-api-server docker://0.0.0.0:5000/quay.io/nmagnezi/assisted-service:appliance2 --dest-tls-verify=false

printf '\\e{yellow}Pushing OC mirror to a local registry...\n\\e{reset}' | set_issue "${status_issue}"
cp /mnt/sr1/bin/oc-mirror /usr/local/bin/
cd /usr/local/bin/
chmod +x oc-mirror
./oc-mirror --from /mnt/sr1/oc-mirror docker://0.0.0.0:5000 --dest-use-http

printf '\\e{yellow}Copying Agent ISO to /dev/sdc...\n\\e{reset}' | set_issue "${status_issue}"
dd if=/dev/sr2 of=/dev/sdc status=progress conv="fsync"

printf '\\e{lightgreen}Done! Please reboot system from /dev/sdc\n\\e{reset}' | set_issue "${status_issue}"
```